### PR TITLE
Fix markdown rendering error showing section header as "Symbol ##"

### DIFF
--- a/_posts/2012-05-26-emacs-lisp-for-hackers-part-1-lisp-essentials.markdown
+++ b/_posts/2012-05-26-emacs-lisp-for-hackers-part-1-lisp-essentials.markdown
@@ -100,7 +100,7 @@ More:
 [Emacs Lisp Reference Manual: Strings](http://www.gnu.org/software/emacs/manual/html_node/elisp/Strings-and-Characters.html#Strings-and-Characters)
 
 
-## Symbols ## 
+## Symbols ##
 
 A symbol is a name for something. Just as names are
 essentially strings, so are symbols just essentially strings.


### PR DESCRIPTION
Fix markdown rendering error showing section header as "Symbol ##". (Deleted a trailing whitespace character)

Great Elisp articles, cheers!
